### PR TITLE
* turn off doxygen in configure.ac and top Makefile.am 

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,7 +2,7 @@ SUBDIRS = src
 dist_doc_DATA = README INSTALL COPYING ChangeLog AUTHORS
 ACLOCAL_AMFLAGS= -I m4
 
-include aminclude.am
+#include aminclude.am
 
 EXTRA_DIST = $(DX_CONFIG) doc/html doc/ltbtoolkit.pdf assets
 

--- a/configure.ac
+++ b/configure.ac
@@ -12,15 +12,15 @@ AC_CONFIG_FILES([
 
 AC_CONFIG_MACRO_DIR([m4])
 
-DX_HTML_FEATURE(ON)
-DX_CHM_FEATURE(OFF)
-DX_CHI_FEATURE(OFF)
-DX_MAN_FEATURE(OFF)
-DX_RTF_FEATURE(OFF)
-DX_XML_FEATURE(OFF)
-DX_PDF_FEATURE(ON)
-DX_PS_FEATURE(OFF)
-DX_INIT_DOXYGEN(ltbToolkit, doxygen.cfg, doc)
+#DX_HTML_FEATURE(ON)
+#DX_CHM_FEATURE(OFF)
+#DX_CHI_FEATURE(OFF)
+#DX_MAN_FEATURE(OFF)
+#DX_RTF_FEATURE(OFF)
+#DX_XML_FEATURE(OFF)
+#DX_PDF_FEATURE(ON)
+#DX_PS_FEATURE(OFF)
+#DX_INIT_DOXYGEN(ltbToolkit, doxygen.cfg, doc)
 
 AM_PROG_AR
 LT_INIT
@@ -30,8 +30,8 @@ AC_OPENMP
 
 AC_CHECK_LIB([gslcblas],[cblas_dgemv])
 AC_CHECK_LIB([gsl],[gsl_spline_init],,
-	[AC_MSG_ERROR(Could not find gsl. Hint (1)  find /usr -name "*gsl*" -print   Hint (2)  install gsl*.a  e.g. from  http://www.gnu.org/software/gsl/ and put it in /usr/local/lib/ or set environment variable LDFLAGS to be -L/my/directory/lib/ with the library and CPPFLAGS to be -I/my/directory/include for the include files.)
-	])
+        [AC_MSG_ERROR(Could not find gsl. Hint (1)  find /usr -name "*gsl*" -print   Hint (2)  install gsl*.a  e.g. from  http://www.gnu.org/software/gsl/ and put it in /usr/local/lib/ or set environment variable LDFLAGS to be -L/my/directory/lib/ with the library and CPPFLAGS to be -I/my/directory/include for the include files.)
+        ])
 
 AC_CHECK_LIB([m], [cos])
 AC_CHECK_FUNCS([floor pow sqrt cbrt])


### PR DESCRIPTION
My out of the box autoconf -i on commit fef6e2274f3961998ed running on debian/jessie gives me:

aclocal: warning: couldn't open directory 'm4': No such file or directory
libtoolize: putting auxiliary files in `.'.
libtoolize: copying file `./ltmain.sh'
libtoolize: putting macros in AC_CONFIG_MACRO_DIR, `m4'.
libtoolize: copying file `m4/libtool.m4'
libtoolize: copying file `m4/ltoptions.m4'
libtoolize: copying file `m4/ltsugar.m4'
libtoolize: copying file `m4/ltversion.m4'
libtoolize: copying file `m4/lt~obsolete.m4'
configure.ac:25: installing './ar-lib'
configure.ac:4: installing './compile'
configure.ac:26: installing './config.guess'
configure.ac:26: installing './config.sub'
configure.ac:3: installing './install-sh'
configure.ac:3: installing './missing'
aminclude.am:35: error: DX_COND_doc does not appear in AM_CONDITIONAL
Makefile.am:5:   'aminclude.am' included from here
aminclude.am:41: error: DX_COND_html does not appear in AM_CONDITIONAL
Makefile.am:5:   'aminclude.am' included from here
aminclude.am:51: error: DX_COND_chm does not appear in AM_CONDITIONAL
Makefile.am:5:   'aminclude.am' included from here
aminclude.am:55: error: DX_COND_chi does not appear in AM_CONDITIONAL
Makefile.am:5:   'aminclude.am' included from here
aminclude.am:67: error: DX_COND_man does not appear in AM_CONDITIONAL
Makefile.am:5:   'aminclude.am' included from here
aminclude.am:77: error: DX_COND_rtf does not appear in AM_CONDITIONAL
Makefile.am:5:   'aminclude.am' included from here
aminclude.am:87: error: DX_COND_xml does not appear in AM_CONDITIONAL
Makefile.am:5:   'aminclude.am' included from here
aminclude.am:97: error: DX_COND_ps does not appear in AM_CONDITIONAL
Makefile.am:5:   'aminclude.am' included from here
aminclude.am:126: error: DX_COND_pdf does not appear in AM_CONDITIONAL
Makefile.am:5:   'aminclude.am' included from here
aminclude.am:155: error: DX_COND_latex does not appear in AM_CONDITIONAL
Makefile.am:5:   'aminclude.am' included from here
src/Makefile.am: installing './depcomp'

Documentation is important, but running code is even more important, so I'm proposing
this hack since I couldn't find a better one.

Cheers
Boud